### PR TITLE
logstream error correction

### DIFF
--- a/source/de/hackcraft/log/LevelStreamLogger.h
+++ b/source/de/hackcraft/log/LevelStreamLogger.h
@@ -41,7 +41,7 @@ public:
     */
     template<typename T>
     LevelStreamLogger& operator<<(const T& val) {
-        logstream << (*(&val));
+        logstream << (int*)(&val);
         appendStream();
         return *this;
     }
@@ -54,7 +54,7 @@ public:
     */
     template<typename T>
     LevelStreamLogger& operator+(const T& val) {
-        logstream << (*(&val));
+        logstream << (int*)(&val);
         appendStream();
         return *this;
     }


### PR DESCRIPTION
This fixes the Logstream logger on Linux, without this change the Linwarrior game fails to compile on Debian Linux 12. I have attempted to compile without this code under GCC 9/10/11/12 and all fail without it.